### PR TITLE
Fixed Issue #17: Added Droplet Deletion

### DIFF
--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -115,13 +115,8 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                         @Override
                         public void onResponse(Call<Action> call, Response<Action> response) {
                             Log.d("DESTROY",String.valueOf(response.code()));
-                            new Handler().postDelayed(new Runnable() {
-                                @Override
-                                public void run() {
-                                    DropletActivity.refreshData();
-                                    finish();
-                                }
-                            }, 5000);
+                            DropletActivity.refreshData();
+                            finish();
                         }
 
                         @Override

--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -1,6 +1,9 @@
 package in.tosc.digitaloceanapp.activities;
 
 import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.design.internal.SnackbarContentLayout;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
@@ -14,6 +17,7 @@ import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.gson.Gson;
 
@@ -99,6 +103,40 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
         if (id == R.id.delete_droplet) {
 
             // TODO: 26/11/16 perform delete
+            new MaterialDialog.Builder(this)
+                    .title(R.string.delete_droplet)
+                    .content(getString(R.string.dialog_delete_droplet_msg,droplet.getName()))
+                    .positiveText("Confirm").onPositive(new MaterialDialog.SingleButtonCallback() {
+                @Override
+                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    Snackbar.make(coordinatorLayout, getString(R.string.delete_droplet_progress), Snackbar.LENGTH_INDEFINITE).show();
+                    doaClient.performAction(droplet.getId(),ActionType.DESTROY,null).enqueue(new Callback<Action>() {
+                        @Override
+                        public void onResponse(Call<Action> call, Response<Action> response) {
+                            Log.d("DESTROY",String.valueOf(response.code()));
+                            new Handler().postDelayed(new Runnable() {
+                                @Override
+                                public void run() {
+                                    DropletActivity.refreshData();
+                                    finish();
+                                }
+                            }, 5000);
+                        }
+
+                        @Override
+                        public void onFailure(Call<Action> call, Throwable t) {
+
+                        }
+                    });
+                }
+            })
+                    .negativeText("Cancel").onNegative(new MaterialDialog.SingleButtonCallback() {
+                @Override
+                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    dialog.dismiss();
+                }
+            })
+                    .show();
             return true;
         } else if (id == R.id.switch_off) {
 

--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -107,7 +107,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
             new MaterialDialog.Builder(this)
                     .title(R.string.delete_droplet)
                     .content(getString(R.string.dialog_delete_droplet_msg,droplet.getName()))
-                    .positiveText("Confirm").onPositive(new MaterialDialog.SingleButtonCallback() {
+                    .positiveText(R.string.dialog_confirm).onPositive(new MaterialDialog.SingleButtonCallback() {
                 @Override
                 public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                     Snackbar.make(coordinatorLayout, getString(R.string.delete_droplet_msg), Snackbar.LENGTH_INDEFINITE).show();
@@ -131,7 +131,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     });
                 }
             })
-                    .negativeText("Cancel").onNegative(new MaterialDialog.SingleButtonCallback() {
+                    .negativeText(R.string.dialog_cancel).onNegative(new MaterialDialog.SingleButtonCallback() {
                 @Override
                 public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
                     dialog.dismiss();

--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -109,7 +109,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     .positiveText("Confirm").onPositive(new MaterialDialog.SingleButtonCallback() {
                 @Override
                 public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                    Snackbar.make(coordinatorLayout, getString(R.string.delete_droplet_progress), Snackbar.LENGTH_INDEFINITE).show();
+                    Snackbar.make(coordinatorLayout, getString(R.string.delete_droplet_msg), Snackbar.LENGTH_INDEFINITE).show();
                     doaClient.performAction(droplet.getId(),ActionType.DESTROY,null).enqueue(new Callback<Action>() {
                         @Override
                         public void onResponse(Call<Action> call, Response<Action> response) {

--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DropletActivity.java
@@ -117,6 +117,13 @@ public class DropletActivity extends AppCompatActivity
             @Override
             public void onResponse(Call<List<Droplet>> call, Response<List<Droplet>> response) {
                 droplets.clear();
+                for(Droplet droplet: response.body())
+                {
+                    if(droplet.isLocked())
+                    {
+                        response.body().remove(droplet);  //A locked droplet prevents any user actions
+                    }
+                }
                 droplets.addAll(response.body());
                 dropletsAdapter.notifyDataSetChanged();
                 Log.e("Droplets fetched", String.valueOf(response.body().size()));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,10 @@
     <string name="network_error">Network error! Please check your internet connection</string>
     <string name="ipv6_cannot_be_disabled">IPv6 cannot be disabled</string>
     <string name="private_network_cannot_be_disabled">Private network cannot be disabled</string>
+    <string name="dialog_delete_droplet_msg">Are you sure you would like to delete %s? This is irreversible. We will destroy your Droplet and all associated backups. All Droplet data will be scrubbed and irretrievable.</string>
+    <string name="dialog_confirm">Confirm</string>
+    <string name="dialog_cancel">Cancel</string>
+    <string name="delete_droplet_msg">Deleting Droplet</string>
 
     <string name="title_activity_droplet_create">DropletCreateActivity</string>
     <string name="dummy_button">Dummy Button</string>

--- a/doandroidlib/src/main/java/in/tosc/doandroidlib/common/ActionType.java
+++ b/doandroidlib/src/main/java/in/tosc/doandroidlib/common/ActionType.java
@@ -35,6 +35,9 @@ public enum ActionType {
   @SerializedName("create")
   CREATE("create"),
 
+  @SerializedName("destroy")
+  DESTROY("destroy"),
+
   @SerializedName("reboot")
   REBOOT("reboot"),
 


### PR DESCRIPTION
I have implemented Droplet Deletion Functionality. One thing I want to mention is when I receive the response code on deleting the droplet, and if I immediately refresh the list of Droplets in `DropletActivity` using `DropletActivity.refreshData()`, I get the deleted droplet as well in the list. Therefore I am refreshing after a duration of 5 secs, in which case its working fine. Need your suggestion on whether this can handled more sophistically.   
![ezgif-1-4ba5a9730b](https://user-images.githubusercontent.com/18742006/27006186-7757bcba-4e4b-11e7-800a-94fc7ede3ccf.gif)

