### PR TITLE
Fixed #43: Fixed issues related to additional options in DetailDropletActivity

### DIFF
--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -208,7 +208,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     });
                 } else {
                     setSwitchWithoutTriggering(switchPrivateNet,true);
-                    Snackbar.make(coordinatorLayout, getString(R.string.private_network_cannot_be_disabled), Snackbar.LENGTH_SHORT);
+                    Snackbar.make(coordinatorLayout, getString(R.string.private_network_cannot_be_disabled), Snackbar.LENGTH_SHORT).show();
                 }
                 break;
 

--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -161,19 +161,24 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     doaClient.performAction(droplet.getId(), ActionType.ENABLE_IPV6, null).enqueue(new Callback<Action>() {
                         @Override
                         public void onResponse(Call<Action> call, Response<Action> response) {
-                            if (response.code() == 200) {
+                            if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.ipv6_enabled), Snackbar.LENGTH_SHORT).show();
                             } else {
                                 Log.d("IPv6", response.code() + "");
+                                setSwitchWithoutTriggering(switchIPv6,false);
+                                Snackbar.make(coordinatorLayout, getString(R.string.ipv6_couldnt_be_enabled), Snackbar.LENGTH_SHORT).show();
+
                             }
                         }
 
                         @Override
                         public void onFailure(Call<Action> call, Throwable t) {
+                            setSwitchWithoutTriggering(switchIPv6,false);
                             Snackbar.make(coordinatorLayout, getString(R.string.network_error), Snackbar.LENGTH_SHORT).show();
                         }
                     });
                 } else {
+                    setSwitchWithoutTriggering(switchIPv6,true);
                     Snackbar.make(coordinatorLayout, getString(R.string.ipv6_cannot_be_disabled), Snackbar.LENGTH_SHORT).show();
                 }
                 break;
@@ -183,19 +188,23 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     doaClient.performAction(droplet.getId(), ActionType.ENABLE_PRIVATE_NETWORKING, null).enqueue(new Callback<Action>() {
                         @Override
                         public void onResponse(Call<Action> call, Response<Action> response) {
-                            if (response.code() == 200) {
+                            if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.private_network_enabled), Snackbar.LENGTH_SHORT).show();
                             } else {
                                 Log.d("SPN", response.code() + "");
+                                setSwitchWithoutTriggering(switchPrivateNet,false);
+                                Snackbar.make(coordinatorLayout, getString(R.string.private_network_couldnt_be_enabled), Snackbar.LENGTH_SHORT).show();
                             }
                         }
 
                         @Override
                         public void onFailure(Call<Action> call, Throwable t) {
+                            setSwitchWithoutTriggering(switchPrivateNet,false);
                             Snackbar.make(coordinatorLayout, getString(R.string.network_error), Snackbar.LENGTH_SHORT).show();
                         }
                     });
                 } else {
+                    setSwitchWithoutTriggering(switchPrivateNet,true);
                     Snackbar.make(coordinatorLayout, getString(R.string.private_network_cannot_be_disabled), Snackbar.LENGTH_SHORT);
                 }
                 break;
@@ -205,15 +214,18 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     doaClient.performAction(droplet.getId(), ActionType.ENABLE_BACKUPS, null).enqueue(new Callback<Action>() {
                         @Override
                         public void onResponse(Call<Action> call, Response<Action> response) {
-                            if (response.code() == 200) {
+                            if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.backup_enabled), Snackbar.LENGTH_SHORT).show();
                             } else {
+                                setSwitchWithoutTriggering(switchBackup,false);
+                                Snackbar.make(coordinatorLayout, getString(R.string.backup_couldnt_be_enabled), Snackbar.LENGTH_SHORT).show();
                                 Log.d("SBE", response.code() + "");
                             }
                         }
 
                         @Override
                         public void onFailure(Call<Action> call, Throwable t) {
+                            setSwitchWithoutTriggering(switchBackup,false);
                             Snackbar.make(coordinatorLayout, getString(R.string.network_error), Snackbar.LENGTH_SHORT).show();
                         }
                     });
@@ -221,15 +233,19 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                     doaClient.performAction(droplet.getId(), ActionType.DISABLE_BACKUPS, null).enqueue(new Callback<Action>() {
                         @Override
                         public void onResponse(Call<Action> call, Response<Action> response) {
-                            if (response.code() == 200) {
-                                Snackbar.make(coordinatorLayout, getString(R.string.backup_diabled), Snackbar.LENGTH_SHORT).show();
+                            if (response.code() >= 200 && response.code()<=299) {
+                                Snackbar.make(coordinatorLayout, getString(R.string.backup_disabled), Snackbar.LENGTH_SHORT).show();
                             } else {
                                 Log.d("SBD", response.code() + "");
+                                setSwitchWithoutTriggering(switchBackup,true);
+                                Snackbar.make(coordinatorLayout, getString(R.string.backup_couldnt_be_disabled), Snackbar.LENGTH_SHORT).show();
+
                             }
                         }
 
                         @Override
                         public void onFailure(Call<Action> call, Throwable t) {
+                            setSwitchWithoutTriggering(switchBackup,true);
                             Snackbar.make(coordinatorLayout, getString(R.string.network_error), Snackbar.LENGTH_SHORT).show();
                         }
                     });
@@ -258,6 +274,13 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
         switchIPv6.setChecked(isIPv6Enabled);
         switchPrivateNet.setChecked(isPrivateNetworkEnabled);
         switchBackup.setChecked(isBackupEnabled);
+    }
+
+    public void setSwitchWithoutTriggering(SwitchCompat switchCompat,boolean newState)
+    {
+        switchCompat.setOnCheckedChangeListener(null);
+        switchCompat.setChecked(newState);
+        switchCompat.setOnCheckedChangeListener(this);
     }
 
 }

--- a/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
+++ b/app/src/main/java/in/tosc/digitaloceanapp/activities/DetailDropletActivity.java
@@ -80,6 +80,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
         switchBackup = (SwitchCompat) findViewById(R.id.switch_backup);
 
         setData(droplet);
+        setIndividualFeatures(droplet);
         setSwitches();
 
         switchIPv6.setOnCheckedChangeListener(this);
@@ -163,6 +164,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                         public void onResponse(Call<Action> call, Response<Action> response) {
                             if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.ipv6_enabled), Snackbar.LENGTH_SHORT).show();
+                                DropletActivity.refreshData();
                             } else {
                                 Log.d("IPv6", response.code() + "");
                                 setSwitchWithoutTriggering(switchIPv6,false);
@@ -190,6 +192,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                         public void onResponse(Call<Action> call, Response<Action> response) {
                             if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.private_network_enabled), Snackbar.LENGTH_SHORT).show();
+                                DropletActivity.refreshData();
                             } else {
                                 Log.d("SPN", response.code() + "");
                                 setSwitchWithoutTriggering(switchPrivateNet,false);
@@ -216,6 +219,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                         public void onResponse(Call<Action> call, Response<Action> response) {
                             if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.backup_enabled), Snackbar.LENGTH_SHORT).show();
+                                DropletActivity.refreshData();
                             } else {
                                 setSwitchWithoutTriggering(switchBackup,false);
                                 Snackbar.make(coordinatorLayout, getString(R.string.backup_couldnt_be_enabled), Snackbar.LENGTH_SHORT).show();
@@ -235,6 +239,7 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
                         public void onResponse(Call<Action> call, Response<Action> response) {
                             if (response.code() >= 200 && response.code()<=299) {
                                 Snackbar.make(coordinatorLayout, getString(R.string.backup_disabled), Snackbar.LENGTH_SHORT).show();
+                                DropletActivity.refreshData();
                             } else {
                                 Log.d("SBD", response.code() + "");
                                 setSwitchWithoutTriggering(switchBackup,true);
@@ -276,11 +281,27 @@ public class DetailDropletActivity extends AppCompatActivity implements Compound
         switchBackup.setChecked(isBackupEnabled);
     }
 
-    public void setSwitchWithoutTriggering(SwitchCompat switchCompat,boolean newState)
+    private void setSwitchWithoutTriggering(SwitchCompat switchCompat,boolean newState)
     {
         switchCompat.setOnCheckedChangeListener(null);
         switchCompat.setChecked(newState);
         switchCompat.setOnCheckedChangeListener(this);
+    }
+
+    private void setIndividualFeatures(Droplet droplet)
+    {
+        droplet.setEnableIpv6(false);
+        droplet.setEnablePrivateNetworking(false);
+        droplet.setEnableBackup(false);
+        for(String feature: droplet.getFeatures())
+        {
+            if(feature.equals("backups"))
+                droplet.setEnableBackup(true);
+            else if(feature.equals("private_networking"))
+                droplet.setEnablePrivateNetworking(true);
+            else if(feature.equals("ipv6"))
+                droplet.setEnableIpv6(true);
+        }
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,12 +40,16 @@
     <string name="ipv6_enabled">IPv6 enabled</string>
     <string name="ipv6_disabled">IPv6 disabled</string>
     <string name="backup_enabled">Backup enabled</string>
-    <string name="backup_diabled">Backup disabled</string>
+    <string name="backup_disabled">Backup disabled</string>
     <string name="private_network_enabled">Private network enabled</string>
-    <string name="private_network_siabled">Private network disabled</string>
+    <string name="private_network_disabled">Private network disabled</string>
     <string name="network_error">Network error! Please check your internet connection</string>
     <string name="ipv6_cannot_be_disabled">IPv6 cannot be disabled</string>
     <string name="private_network_cannot_be_disabled">Private network cannot be disabled</string>
+    <string name="ipv6_couldnt_be_enabled">IPv6 could not be enabled</string>
+    <string name="private_network_couldnt_be_enabled">Private network could not be enabled</string>
+    <string name="backup_couldnt_be_enabled">Backup could not be enabled</string>
+    <string name="backup_couldnt_be_disabled">Backup could not be disabled</string>
 
     <string name="title_activity_droplet_create">DropletCreateActivity</string>
     <string name="dummy_button">Dummy Button</string>


### PR DESCRIPTION
Fixed Issue 1- Now snackbar shows up whenever a switch is pressed. 
Fixed Issue 3- User can't disable IPv6 or private networking if they were enabled.
![ezgif-1-4ba5a9730b](https://user-images.githubusercontent.com/18742006/27007065-35bef6ac-4e63-11e7-9a42-ab2fe5685454.gif)
**NOTE** - In the above GIF, Private networking could not be enabled as it requires the droplet to remain off.
 
Fixed Issue 2 - On going back from `DetailDropletActivity` or on closing the app, whenever `DetailDropletActivity` is opened again, the states of switches reflect the actual settings and do not necessarily remain off. 
![ezgif-1-cca7e57fac](https://user-images.githubusercontent.com/18742006/27007094-4a1050e6-4e64-11e7-907b-2a8c8a14075e.gif)



