### PR TITLE
Update of dependencies and build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk: oraclejdk8
 env:
   global:
     - GRADLE_OPTS="-Xmx512m"
-    - BUILD_TOOLS="25.0.2"
+    - BUILD_TOOLS="27.0.3"
     - TARGET_SDK=25
   matrix:
     - EMULATOR_API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,32 +38,32 @@ ext {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.android.support:appcompat-v7:$supportLibraryVersion"
-    compile "com.android.support:support-v13:$supportLibraryVersion"
-    compile "com.android.support:design:$supportLibraryVersion"
-    compile "com.android.support:support-v4:$supportLibraryVersion"
-    compile "com.android.support:cardview-v7:$supportLibraryVersion"
-    compile "com.android.support:customtabs:$supportLibraryVersion"
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'de.hdodenhof:circleimageview:2.1.0'
-    compile 'com.afollestad.material-dialogs:core:0.9.1.0'
-    compile project(path: ':doandroidlib')
-    testCompile 'junit:junit:4.12'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:support-v13:$supportLibraryVersion"
+    implementation "com.android.support:design:$supportLibraryVersion"
+    implementation "com.android.support:support-v4:$supportLibraryVersion"
+    implementation "com.android.support:cardview-v7:$supportLibraryVersion"
+    implementation "com.android.support:customtabs:$supportLibraryVersion"
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'de.hdodenhof:circleimageview:2.1.0'
+    implementation 'com.afollestad.material-dialogs:core:0.9.1.0'
+    implementation project(path: ':doandroidlib')
+    testImplementation 'junit:junit:4.12'
 
-    androidTestCompile('com.android.support.test:runner:0.5') {
+    androidTestImplementation('com.android.support.test:runner:0.5') {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
-    androidTestCompile('com.android.support.test:rules:0.5') {
+    androidTestImplementation('com.android.support.test:rules:0.5') {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2') {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2') {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
-    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2') {
+    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:2.2.2') {
         exclude module: 'support-annotations'
         exclude module: 'support-v4'
         exclude module: 'support-v13'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'jacoco-everywhere'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "27.0.3"
     defaultConfig {
         applicationId "in.tosc.digitaloceanapp"
         minSdkVersion 16
@@ -12,25 +12,31 @@ android {
         versionName "0.2.0"
         testInstrumentationRunner "in.tosc.digitaloceanapp.DOAppTestRunner"
     }
+
     lintOptions {
         abortOnError false
     }
+
     useLibrary 'org.apache.http.legacy'
+
     buildTypes {
         debug {
             testCoverageEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }
+
 ext {
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '25.4.0'
 }
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile "com.android.support:appcompat-v7:$supportLibraryVersion"
@@ -44,16 +50,20 @@ dependencies {
     compile 'com.afollestad.material-dialogs:core:0.9.1.0'
     compile project(path: ':doandroidlib')
     testCompile 'junit:junit:4.12'
-    androidTestCompile ('com.android.support.test:runner:0.5') {
-        exclude group:'com.android.support', module:'support-annotations'
+
+    androidTestCompile('com.android.support.test:runner:0.5') {
+        exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile ('com.android.support.test:rules:0.5') {
-        exclude group:'com.android.support', module:'support-annotations'
+
+    androidTestCompile('com.android.support.test:rules:0.5') {
+        exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile ('com.android.support.test.espresso:espresso-core:2.2.2') {
-        exclude group:'com.android.support', module:'support-annotations'
+
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile ('com.android.support.test.espresso:espresso-contrib:2.2.2') {
+
+    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2') {
         exclude module: 'support-annotations'
         exclude module: 'support-v4'
         exclude module: 'support-v13'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'com.android.application'
-apply plugin: 'jacoco-everywhere'
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = '0.8.0'
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
 
 android {
     compileSdkVersion 25

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -16,6 +20,10 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
+        classpath 'org.jacoco:org.jacoco.core:0.8.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/doandroidlib/build.gradle
+++ b/doandroidlib/build.gradle
@@ -31,12 +31,12 @@ ext {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'me.panavtec:wizard:1.2'
-    compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
-    testCompile 'junit:junit:4.12'
+    api fileTree(dir: 'libs', include: ['*.jar'])
+    api 'com.android.support:appcompat-v7:25.4.0'
+    api 'org.apache.commons:commons-lang3:3.4'
+    api 'com.google.code.gson:gson:2.8.2'
+    api 'me.panavtec:wizard:1.2'
+    api "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    api "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    testImplementation 'junit:junit:4.12'
 }

--- a/doandroidlib/build.gradle
+++ b/doandroidlib/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'jacoco-everywhere'
 
-group='com.coding-blocks'
+group = 'com.coding-blocks'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
@@ -15,8 +15,6 @@ android {
         versionName "0.1.1"
 
         consumerProguardFiles 'proguard-rules.pro'
-
-
     }
     lintOptions {
         abortOnError false
@@ -34,9 +32,9 @@ ext {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
     compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.google.code.gson:gson:2.7'
+    compile 'com.google.code.gson:gson:2.8.2'
     compile 'me.panavtec:wizard:1.2'
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
     compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"

--- a/doandroidlib/build.gradle
+++ b/doandroidlib/build.gradle
@@ -1,8 +1,16 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'jacoco-everywhere'
+apply plugin: 'jacoco'
 
 group = 'com.coding-blocks'
+
+jacoco {
+    toolVersion = '0.8.0'
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
 
 android {
     compileSdkVersion 25

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu May 17 23:14:29 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
# PR Request to update dependencies and build tools

## What's it do?

Updates the Gradle build tools, Google GSON library, adds the Google Maven repository to all modules, and updates all compile/testCompile references to their non-deprecated versions.

## What was wrong?

The versions were simply out of date and needed updating and verification that no problems occurred as a result.

## How's it fixed?

1. All the versions were updated at first, however, they needed the Google repository.

2. I added the Google Maven repository in the build files so they could be located.

3. The build files still used `compile` and `testCompile` which was throwing warnings about the plan to [stop supporting them][1] by the end of 2018 so I updated their references:
    - In the app `build.gradle` file, they needed to be changed to `implementation` and `testImplementation` respectively.
    - In the library's `build.gradle` file, they needed to be changed to `api` and `testImplementation` respectively.

[1]: https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration#new_configurations