### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - BUILD_TOOLS="27.0.3"
     - TARGET_SDK=27
   matrix:
+  fast_finish: true
     - EMULATOR_API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - EMULATOR_API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - EMULATOR_API=26 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ env:
     - BUILD_TOOLS="27.0.3"
     - TARGET_SDK=27
   matrix:
-  fast_finish: true
     - EMULATOR_API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - EMULATOR_API=21 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - EMULATOR_API=26 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
 #    - EMULATOR_API=25 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
 matrix:
+  fast_finish: true
   allow_failures:
     - env: EMULATOR_API=26 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis
     - env: EMULATOR_API=19 ANDROID_ABI=armeabi-v7a ANDROID_TAG=google_apis


### PR DESCRIPTION

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
